### PR TITLE
chore: enforce dependabot daily config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR ensures Dependabot is configured correctly (only for detected ecosystems) and runs daily. No auto-merge.